### PR TITLE
fix pepperbot thinking embeds are always delicious

### DIFF
--- a/sandwich.js
+++ b/sandwich.js
@@ -80,7 +80,7 @@ function sandwich(hash) {
     switch (hash.charAt(6)) {
         case '0':
         case '1': {
-            const inner = sandwich(hash.substring(6));
+            const inner = sandwich(hash.substring(7));
             if (inner) {
                 output.push('embedded in a');
                 output.push(inner);


### PR DESCRIPTION
Problem:
 - sandwich() inspects the first 7 characters (0-6) of the input
 - but it only drops the first 6 if it detects an embed (hash[6] = 0 or 1)
 - this results in every substring passed in the recursive call starting with 0 or 1
 - as a result, if a sandwich is embedded in another sandwich, pepperbot always
   things the outer sandwich is delicious

Solution:
 - drop the first 7 characters so there is no overlap between the characters inspected
   in the original and recursive calls