### PR TITLE
chore: add helper function to make it easier to prefix an input with 'a' or 'an'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 npm-debug.log
 .DS_Store
 /*.env
+.prettierignore
 

--- a/celeste.js
+++ b/celeste.js
@@ -1,3 +1,5 @@
+const { aOrAn } = require("./helpers/aOrAn");
+
 function prefix_from(prefixes) {
     if (prefixes.length === 0) {
         return "";
@@ -98,12 +100,7 @@ function tech() {
 
 function command(chatClient, channel) {
     const message = tech();
-    // If message starts with a vowel
-    if (["a", "e", "i", "o", "u"].includes(message[0])) {
-        chatClient.say(channel, `Simply do an ${message}`);
-    } else {
-        chatClient.say(channel, `Simply do a ${message}`);
-    }
+    chatClient.say(channel, `Simply do ${aOrAn(message)} ${message}`);
 }
 
 module.exports = { command };

--- a/helpers/aOrAn.js
+++ b/helpers/aOrAn.js
@@ -1,0 +1,11 @@
+function aOrAn(input) {
+  if (!input) return ''
+
+  const firstChar = input[0];
+
+  return ['a', 'e', 'i', 'o', 'u'].includes(firstChar.toLowerCase()) 
+  ? 'an' 
+  : 'a';
+}
+
+module.exports = { aOrAn };

--- a/sandwich.js
+++ b/sandwich.js
@@ -1,4 +1,5 @@
 const sha256 = require('crypto-js/sha256');
+const { aOrAn } = require('./helpers/aOrAn');
 
 function sandwich(hash) {
     const output = []
@@ -100,7 +101,7 @@ function command(chatClient, channel, input) {
 
     const result = sandwich(hash);
     if (result) {
-        chatClient.say(channel, `Yes, ${input} is a ${result}`);
+        chatClient.say(channel, `Yes, ${input} is ${aOrAn(result)} ${result}`);
     } else {
         chatClient.say(channel, `No, ${input} is not a sandwich`);
     }


### PR DESCRIPTION
This PR adds a helper function for certain inputs that need logic for determining if it should be preceded by an 'a' or an 'an' (i.e. "a sandwich" or "an inverse sandwich"). This helper function is added to `celeste.js` and `sandwich.js`