### PR TITLE
feature: Numberwang

### DIFF
--- a/first.js
+++ b/first.js
@@ -101,6 +101,9 @@ async function nth(chatClient, apiClient, online, channel, db, user, n) {
             await db.query('INSERT INTO nth (user_name, n, type) VALUES ($1, $2, $3)', [user, n, 'max']);
             chatClient.say(channel, `IT'S A NEW WORLD RECORD! ${user} gets ${ordinal(n)} for the first time!`);
         }
+        if (n > 1 && Math.random() < 0.01){
+            chatClient.say(channel, `And that's numberwang!`);
+        }
     } else {
         chatClient.say(channel, `Sorry, ${user}, you can't be ${ordinal(n)} because nobody was ${ordinal(n - 1)}.`);
     }


### PR DESCRIPTION
Implementation of Numberwang into Pepper's Nth game.

This implementation of Numberwang allows players to knowingly or unknowingly enjoy the game of Numberwang while participating in usual stream activities. For newer or unknowing players, this can serve as a fun "meter-high diving board" into the effervescent wangly depths of numerology. Playing with the system and scoring will guide an intuition for Numberwang, replete with all the benefits of developing this aspect of the cerebellum. For veterans, mastering the intricacies of a brave new medium can provide a refreshing and challenging new experience of a long-loved favorite game.

Considerations in adapting Numberwang into "chatbot" format have been taken. This implementation does not infringe copyright law, thus doesn't deprive people of legitimate royalties nor jeopardize future game show production. Participants need not fear a prison sentence of up to 20 years under the game show criminality act of 1998.

Being targeted to a primarily American and Canadian audience, this implementation uses Americanized rules where possible. Codices 17-19 of the official English ruleset can be disregarded, as American audiences wouldn't rightly be able to get their heads wrapped around those ones, would they? Gameplay has been streamlined but not made any less exciting, based on inspiration from Compendium 2B, subsection A006-J, which informs the design principles for adapting to live online, highly-multiplayer play.

This implementation is highly performant, and should not have an impact on Sgt. Pepper's ability to service his community. Due to technical restrictions, players of this implementation will be limited to positive, incrementing integers alone, which the rules have accounted for, and provides an exciting challenge limitation on players. Surreals are right out!!

The primary perceived failing of this implementation is an inability to turn the board round. This is upsetting. A team of moderators is nearly mandatory for establishing order and morale. Optionally at the streamers' discretion, wangnumb can be implemented by moderators, by giving timeouts to all wangnumb losers. Ha ha ha, too bad for them.

Adding Numberwang into Sgt. Pepper is meritorious on a level approaching Kantian categorical imperative. The joy viewers may have in achieving or seeking numberwangs is great. This increases engagement with the Nth game, with the stream, and with the natural universe. It is this requester's measured recommendation that the numberwang feature be added to Sgt. Pepper's many capabilities, forthright.